### PR TITLE
修复接口返回信息'no data'加了空格的问题

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -156,7 +156,7 @@ function getQuestion() {
             } catch (e) {
                 resolve(false)
             }
-            if (ret.msg === 'no data') {
+            if (ret.msg.trim() === 'no data') {
                 resolve(json)
             } else {
                 resolve(ret)


### PR DESCRIPTION
虚浮由于请求的接口返回的`no data`在后面加了空格，导致程序运行失败的问题。